### PR TITLE
Fixed button management

### DIFF
--- a/src/adaptiveCardExtensions/companyCommunicator/cardView/LargeCardView.ts
+++ b/src/adaptiveCardExtensions/companyCommunicator/cardView/LargeCardView.ts
@@ -48,7 +48,7 @@ export class LargeCardView extends BaseImageCardView<ICompanyCommunicatorAdaptiv
         });
       }
 
-      if (this.state.currentIndex < this.properties.count-1) {
+      if (this.state.currentIndex < this.state.messages.length -1) {
         buttons.push({
           id: "next",
           title: strings.NextButton,


### PR DESCRIPTION
When you display a large card, the visibility of the "Next" button is wrongly calculated based on the number of properties set in the panel, instead on the number of available messages. This leads the button to be displayed even when there are no more messages to display,